### PR TITLE
Add last version of Google Java Format

### DIFF
--- a/subprojects/format/src/main/groovy/com/github/sherter/googlejavaformatgradleplugin/format/Gjf.java
+++ b/subprojects/format/src/main/groovy/com/github/sherter/googlejavaformatgradleplugin/format/Gjf.java
@@ -9,7 +9,7 @@ public class Gjf {
   public static final String ARTIFACT_ID = "google-java-format";
 
   public static final ImmutableList<String> SUPPORTED_VERSIONS =
-      ImmutableList.of("1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6");
+      ImmutableList.of("1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7");
 
   /**
    * Constructs a new formatter that delegates to <a


### PR DESCRIPTION
As in 10 of January Google release version 1.7 of Google Java Format (https://github.com/google/google-java-format/releases/tag/google-java-format-1.7), I added this last version to the supported versions to keep the plugin updated. 