### PR TITLE
Fix configuration cache

### DIFF
--- a/src/main/groovy/com/github/sherter/googlejavaformatgradleplugin/GoogleJavaFormatPlugin.groovy
+++ b/src/main/groovy/com/github/sherter/googlejavaformatgradleplugin/GoogleJavaFormatPlugin.groovy
@@ -38,9 +38,15 @@ class GoogleJavaFormatPlugin implements Plugin<Project> {
 
         SharedContext context = new SharedContext(project, extension)
         TaskConfigurator configurator = new TaskConfigurator(context)
-        project.gradle.taskGraph.beforeTask { Task task ->
-            if (task.project == this.project && task instanceof FormatTask) {
+        if (SUPPORTS_LAZY_TASKS) {
+            project.tasks.withType(FormatTask).configureEach { FormatTask task ->
                 task.accept(configurator)
+            }
+        } else {
+            project.gradle.taskGraph.beforeTask { Task task ->
+                if (task.project == this.project && task instanceof FormatTask) {
+                    task.accept(configurator)
+                }
             }
         }
     }


### PR DESCRIPTION
Fix configuration cache by using Gradle's lazy task configuration api to A. only configure tasks in current project and B. only tasks with type FormatTask. This maintains feature parity with existing plugin.

The existing beforeTask call is kept for users of gradle < 4.9

Resolves https://github.com/sherter/google-java-format-gradle-plugin/issues/55