### PR TITLE
Add GitHub workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        show-progress: false
+
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'adopt'
+        java-version: '8'
+
+    - name: Build with Gradle
+      run: ./gradlew build
+
+    - name: Run tests
+      run: ./gradlew test
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: build-artifacts
+        path: build/libs/*.jar

--- a/subprojects/format/src/main/groovy/com/github/sherter/googlejavaformatgradleplugin/format/Gjf.java
+++ b/subprojects/format/src/main/groovy/com/github/sherter/googlejavaformatgradleplugin/format/Gjf.java
@@ -9,7 +9,8 @@ public class Gjf {
   public static final String ARTIFACT_ID = "google-java-format";
 
   public static final ImmutableList<String> SUPPORTED_VERSIONS =
-      ImmutableList.of("1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "1.10.0", "1.11.0");
+      ImmutableList.of(
+          "1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "1.10.0", "1.11.0");
 
   /**
    * Constructs a new formatter that delegates to <a


### PR DESCRIPTION
This adds a GitHub workflow.

For OSS projects, GitHub workflows are for free - and better integrated into GitHub than Azure CI.

Closes https://github.com/sherter/google-java-format-gradle-plugin/pull/37